### PR TITLE
buttonIcon -> controlBar TS

### DIFF
--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -333,6 +333,28 @@ export class EuiControlBar extends Component<
             );
           }
 
+          const {
+            label,
+            'aria-labelledby': ariaLabelledby,
+            'aria-hidden': ariaHidden,
+            ...buttonIconRest
+          } = rest as IconButtonControlType;
+
+          let buttonIconProps: ExclusiveUnion<
+            { 'aria-hidden': true },
+            ExclusiveUnion<
+              { label: React.ReactNode },
+              { 'aria-labelledby': string }
+            >
+          > = { label: label };
+          if (ariaHidden && ariaHidden === true) {
+            buttonIconProps = { 'aria-hidden': ariaHidden };
+          } else {
+            if (ariaLabelledby) {
+              buttonIconProps = { 'aria-labelledby': ariaLabelledby };
+            }
+          }
+
           return (
             <EuiButtonIcon
               key={id + index}
@@ -341,8 +363,9 @@ export class EuiControlBar extends Component<
               onClick={onClick}
               href={href}
               color={color as EuiButtonIconProps['color']}
-              {...rest}
               size="s"
+              {...buttonIconProps}
+              {...buttonIconRest}
             />
           );
         }


### PR DESCRIPTION
Surely there is some refactoring and cleaning up that could be done (e.g., not redefining the double `ExclusiveUnion` type from `EuiButtonIcon`), but control_bar is error-free now
