### PR TITLE
Deprecate toggle

### DIFF
--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -97,6 +97,7 @@ const buttonToggleSnippet = [
 </EuiButton>`,
 ];
 
+import { EuiButtonGroupOption } from './props';
 import ButtonGroup from './button_group';
 const buttonGroupSource = require('!!raw-loader!./button_group');
 const buttonGroupHtml = renderToHtml(ButtonGroup);
@@ -389,7 +390,7 @@ export const ButtonExample = {
       ),
       demo: <ButtonGroup />,
       snippet: buttonGroupSnippet,
-      props: { EuiButtonGroup },
+      props: { EuiButtonGroup, EuiButtonGroupOption },
     },
     {
       title: 'Ghost',

--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -103,17 +103,28 @@ const buttonGroupHtml = renderToHtml(ButtonGroup);
 const buttonGroupSnippet = [
   `<EuiButtonGroup
   legend={legend}
-  options={this.toggleButtons}
-  idSelected={this.state.toggleIdSelected}
-  onChange={this.onChange}
+  options={[
+    {
+      id: optionId,
+      label: 'Option'
+    }
+  ]}
+  idSelected={idSelected}
+  onChange={(optionId) => {}}
 />`,
   `<EuiButtonGroup
-  legend={legend}
-  options={this.toggleButtonsIconsMulti}
-  idToSelectedMap={this.state.toggleIconIdToSelectedMap}
-  onChange={this.onChangeIconsMulti}
   type="multi"
   isIconOnly
+  legend={legend}
+  options={[
+    {
+      id: optionId,
+      label: 'Option',
+      iconType: 'iconString',
+    }
+  ]}
+  idToSelectedMap={idToSelectedMap}
+  onChange={(optionId) => {}}
 />`,
 ];
 
@@ -349,10 +360,8 @@ export const ButtonExample = {
       text: (
         <div>
           <p>
-            <strong>EuiButtonGroups</strong> are handled similarly to the way
-            checkbox and radio groups are handled but made to look like buttons.
-            They group multiple <strong>EuiButtonToggles</strong> and utilize
-            the <EuiCode language="js">type=&quot;single&quot;</EuiCode> or{' '}
+            <strong>EuiButtonGroups</strong> utilize the{' '}
+            <EuiCode language="js">type=&quot;single&quot;</EuiCode> or{' '}
             <EuiCode language="js">&quot;multi&quot;</EuiCode> prop to determine
             whether multiple or only single selections are allowed per group.
           </p>
@@ -370,8 +379,9 @@ export const ButtonExample = {
             title={
               <span>
                 In order for groups to be properly read as groups with a title,
-                add the <EuiCode>legend</EuiCode> prop. This is only for
-                accessibility, however, so it will be visibly hidden.
+                the <EuiCode>legend</EuiCode> prop is <strong>required</strong>.
+                This is only for accessibility, however, so it will be visibly
+                hidden.
               </span>
             }
           />

--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -82,17 +82,18 @@ const buttonToggleSource = require('!!raw-loader!./button_toggle');
 const buttonToggleHtml = renderToHtml(ButtonToggle);
 const buttonToggleSnippet = [
   `<EuiButton
-  iconType={this.state.toggleOn ? onIcon : offIcon}
-  onClick={this.onToggleChange}
+  iconType={toggleOn ? onIcon : offIcon}
+  onClick={onToggleChange}
 >
-  {this.state.toggleOn ? onLabel : offLabel}
+  {toggleOn ? onLabel : offLabel}
 </EuiButton>
 `,
   `<EuiButton
-  aria-pressed={this.state.toggleOn}
-  onChange={this.onToggleChange}
+  aria-pressed={toggleOn}
+  fill={toggleOn}
+  onChange={onToggleChange}
 >
-  {buttonText}
+  <!-- Button text -->
 </EuiButton>`,
 ];
 
@@ -309,11 +310,25 @@ export const ButtonExample = {
               </span>
             }
           />
-          <EuiSpacer size="s" />
+          <EuiSpacer size="m" />
           <p>
-            Pass in <EuiCode>aria-pressed</EuiCode> if your button does not
-            change its label for each state.
+            You can create a toggle style button with any button type like the
+            standard <strong>EuiButton</strong>, <strong>EuiButtonEmpty</strong>{' '}
+            or <strong>EuiButtonIcon</strong>. Simpy use state management to
+            handle the visual differences for on and off. Though there are two
+            situations to consider.
           </p>
+          <ul>
+            <li>
+              If your button changes its <strong>content</strong>, the text,
+              then there is no additional accessibility concern.
+            </li>
+            <li>
+              If your button only changes the <strong>visual</strong>{' '}
+              appearance, you must add <EuiCode>aria-pressed</EuiCode> for the{' '}
+              {'"on"'} state.
+            </li>
+          </ul>
         </>
       ),
       demo: <ButtonToggle />,

--- a/src-docs/src/views/button/button_group.js
+++ b/src-docs/src/views/button/button_group.js
@@ -24,8 +24,7 @@ export default class extends Component {
       },
       {
         id: `${idPrefix}1`,
-        label:
-          'Option two is selected by default Option two is selected by default',
+        label: 'Option two is selected by default',
       },
       {
         id: `${idPrefix}2`,
@@ -55,8 +54,7 @@ export default class extends Component {
       },
       {
         id: `${idPrefix2}1`,
-        label:
-          'Option 2 is selected by default Option 2 is selected by default',
+        label: 'Option 2 is selected by default',
       },
       {
         id: `${idPrefix2}2`,

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -11,10 +11,35 @@ export default () => {
   const [toggle0On, setToggle0On] = useState(false);
   const [toggle1On, setToggle1On] = useState(false);
   const [toggle2On, setToggle2On] = useState(true);
-  const [toggle3On, setToggle3On] = useState(true);
+  const [toggle3On, setToggle3On] = useState(false);
 
   return (
     <>
+      <EuiTitle size="xxs">
+        <h3>Changing content</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiButton
+        fill={toggle1On}
+        onClick={() => {
+          setToggle1On(!toggle1On);
+        }}>
+        {toggle1On ? 'I am a filled toggle' : 'I am a primary toggle'}
+      </EuiButton>
+      &emsp;
+      <EuiButtonIcon
+        title={toggle2On ? 'Play' : 'Pause'}
+        aria-label={toggle2On ? 'Play' : 'Pause'}
+        iconType={toggle2On ? 'play' : 'pause'}
+        onClick={() => {
+          setToggle2On(!toggle2On);
+        }}
+      />
+      <EuiSpacer size="m" />
+      <EuiTitle size="xxs">
+        <h3>Changing visual appearance</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
       <EuiButton
         fill={toggle0On}
         aria-pressed={toggle0On}
@@ -22,45 +47,19 @@ export default () => {
         onClick={() => {
           setToggle0On(!toggle0On);
         }}>
-        Toggle Me
+        Toggle me
       </EuiButton>
-      &emsp;
-      <EuiButton
-        fill={toggle1On}
-        onClick={() => {
-          setToggle1On(!toggle1On);
-        }}>
-        {toggle1On ? 'I am a primary toggle' : 'I am a filled toggle'}
-      </EuiButton>
-      &emsp;
-      <EuiButtonIcon
-        aria-label={toggle2On ? 'Play' : 'Pause'}
-        iconType={toggle2On ? 'play' : 'pause'}
-        onClick={() => {
-          setToggle2On(!toggle2On);
-        }}
-      />
       &emsp;
       <EuiButtonIcon
         aria-label="Autosave"
+        title="Autosave"
         iconType="save"
         aria-pressed={toggle3On}
+        color={toggle3On ? 'primary' : 'subdued'}
         onClick={() => {
           setToggle3On(!toggle3On);
         }}
       />
-      <EuiSpacer size="m" />
-      <EuiTitle size="xxs">
-        <h3>Disabled</h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiButton isDisabled={true} fill={false}>
-        Can&apos;t toggle this
-      </EuiButton>
-      &emsp;
-      <EuiButton isDisabled={true} fill={true}>
-        Can&apos;t toggle this either
-      </EuiButton>
     </>
   );
 };

--- a/src-docs/src/views/button/props.tsx
+++ b/src-docs/src/views/button/props.tsx
@@ -1,0 +1,6 @@
+import React, { FunctionComponent } from 'react';
+import { EuiButtonGroupOptionProps } from '../../../../src/components/button/button_group';
+
+export const EuiButtonGroupOption: FunctionComponent<
+  EuiButtonGroupOptionProps
+> = () => <div />;

--- a/src-docs/src/views/form_compressed/complex_example.js
+++ b/src-docs/src/views/form_compressed/complex_example.js
@@ -22,11 +22,10 @@ import {
   EuiSuperSelect,
   EuiToolTip,
 } from '../../../../src/components';
-import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
-  const idPrefix = htmlIdGenerator();
-  const idPrefix1 = htmlIdGenerator();
+  const idPrefix = 'styleToggle';
+  const idPrefix1 = 'granularityToggle';
 
   const typeStyleToggleButtons = [
     {

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -33,12 +33,9 @@
 
   &:not(.euiButton--disabled) {
     &:hover,
+    &:focus,
     &:active {
       @include euiSlightShadowHover;
-    }
-
-    &:hover,
-    &:focus {
       background-color: transparentize($euiColorPrimary, .9);
     }
   }
@@ -116,7 +113,7 @@
 }
 
 // Fix ghost/disabled look specifically
-.euiButton--disabled.euiButton--ghost {
+.euiButton.euiButton--disabled.euiButton--ghost {
   &,
   &:hover,
   &:focus {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -35,7 +35,7 @@ export type ButtonColor =
 
 export type ButtonSize = 's' | 'm';
 
-export const colorToClassNameMap: { [color in ButtonColor]: string } = {
+const colorToClassNameMap: { [color in ButtonColor]: string } = {
   primary: 'euiButton--primary',
   secondary: 'euiButton--secondary',
   warning: 'euiButton--warning',

--- a/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`EuiButtonGroup is rendered 1`] = `
   <div
     aria-label="aria-label"
     class="euiButtonGroup euiButtonGroup--text testClass1 testClass2"
+    data-test-subj="test subject string"
   />
 </fieldset>
 `;
@@ -29,7 +30,7 @@ exports[`EuiButtonGroup props buttonSize compressed is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text euiButtonGroup--compressed"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -48,7 +49,7 @@ exports[`EuiButtonGroup props buttonSize compressed is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -67,7 +68,7 @@ exports[`EuiButtonGroup props buttonSize compressed is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -102,7 +103,7 @@ exports[`EuiButtonGroup props buttonSize m is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -121,7 +122,7 @@ exports[`EuiButtonGroup props buttonSize m is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -140,7 +141,7 @@ exports[`EuiButtonGroup props buttonSize m is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -175,7 +176,7 @@ exports[`EuiButtonGroup props buttonSize s is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -194,7 +195,7 @@ exports[`EuiButtonGroup props buttonSize s is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -213,7 +214,7 @@ exports[`EuiButtonGroup props buttonSize s is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -248,7 +249,7 @@ exports[`EuiButtonGroup props color danger is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--danger"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--danger euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -267,7 +268,7 @@ exports[`EuiButtonGroup props color danger is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--danger euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -286,7 +287,7 @@ exports[`EuiButtonGroup props color danger is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--danger euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -321,7 +322,7 @@ exports[`EuiButtonGroup props color ghost is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--ghost"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--ghost euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -340,7 +341,7 @@ exports[`EuiButtonGroup props color ghost is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--ghost euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -359,7 +360,7 @@ exports[`EuiButtonGroup props color ghost is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--ghost euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -394,7 +395,7 @@ exports[`EuiButtonGroup props color primary is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--primary"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--primary euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -413,7 +414,7 @@ exports[`EuiButtonGroup props color primary is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--primary euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -432,7 +433,7 @@ exports[`EuiButtonGroup props color primary is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--primary euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -467,7 +468,7 @@ exports[`EuiButtonGroup props color secondary is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--secondary"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--secondary euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -486,7 +487,7 @@ exports[`EuiButtonGroup props color secondary is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--secondary euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -505,7 +506,7 @@ exports[`EuiButtonGroup props color secondary is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--secondary euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -540,7 +541,7 @@ exports[`EuiButtonGroup props color text is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -559,7 +560,7 @@ exports[`EuiButtonGroup props color text is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -578,7 +579,7 @@ exports[`EuiButtonGroup props color text is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -613,7 +614,7 @@ exports[`EuiButtonGroup props color warning is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--warning"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--warning euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -632,7 +633,7 @@ exports[`EuiButtonGroup props color warning is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--warning euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -651,7 +652,7 @@ exports[`EuiButtonGroup props color warning is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--warning euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -686,7 +687,7 @@ exports[`EuiButtonGroup props idSelected is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--fill euiButton--small euiButtonGroup__button euiButton--no-hover euiButtonGroup__button--selected"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--fill euiButton--small euiButtonGroup__button euiButtonGroup__button--selected"
     >
       <input
         checked=""
@@ -706,7 +707,7 @@ exports[`EuiButtonGroup props idSelected is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -725,7 +726,7 @@ exports[`EuiButtonGroup props idSelected is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -760,7 +761,7 @@ exports[`EuiButtonGroup props isDisabled is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text euiButtonGroup--disabled"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--disabled euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--disabled euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -780,7 +781,7 @@ exports[`EuiButtonGroup props isDisabled is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--disabled euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--disabled euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -800,7 +801,7 @@ exports[`EuiButtonGroup props isDisabled is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--disabled euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--disabled euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -836,7 +837,7 @@ exports[`EuiButtonGroup props isFullWidth is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text euiButtonGroup--fullWidth"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -855,7 +856,7 @@ exports[`EuiButtonGroup props isFullWidth is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -874,7 +875,7 @@ exports[`EuiButtonGroup props isFullWidth is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -909,7 +910,7 @@ exports[`EuiButtonGroup props isIconOnly is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButton--no-hover euiButtonGroup__button--iconOnly"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
     >
       <input
         class="euiButtonGroup__input"
@@ -928,7 +929,7 @@ exports[`EuiButtonGroup props isIconOnly is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButton--no-hover euiButtonGroup__button--iconOnly"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
     >
       <input
         class="euiButtonGroup__input"
@@ -947,7 +948,7 @@ exports[`EuiButtonGroup props isIconOnly is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButton--no-hover euiButtonGroup__button--iconOnly"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
     >
       <input
         class="euiButtonGroup__input"
@@ -982,7 +983,7 @@ exports[`EuiButtonGroup props legend is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1001,7 +1002,7 @@ exports[`EuiButtonGroup props legend is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1020,7 +1021,7 @@ exports[`EuiButtonGroup props legend is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1055,7 +1056,7 @@ exports[`EuiButtonGroup props name is rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1075,7 +1076,7 @@ exports[`EuiButtonGroup props name is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1095,7 +1096,7 @@ exports[`EuiButtonGroup props name is rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1131,7 +1132,7 @@ exports[`EuiButtonGroup props options are rendered 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1150,7 +1151,7 @@ exports[`EuiButtonGroup props options are rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1169,7 +1170,7 @@ exports[`EuiButtonGroup props options are rendered 1`] = `
       </label>
     </div>
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1204,8 +1205,7 @@ exports[`EuiButtonGroup props options can pass down data-test-subj 1`] = `
     class="euiButtonGroup euiButtonGroup--text"
   >
     <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
-      data-test-subj="test"
+      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
     >
       <input
         class="euiButtonGroup__input"
@@ -1242,7 +1242,7 @@ exports[`EuiButtonGroup props type of multi idToSelectedMap is rendered 1`] = `
   >
     <button
       aria-pressed="true"
-      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover euiButtonGroup__button--selected euiButton--fill"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
       id="button00"
       type="button"
     >
@@ -1258,7 +1258,7 @@ exports[`EuiButtonGroup props type of multi idToSelectedMap is rendered 1`] = `
     </button>
     <button
       aria-pressed="true"
-      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover euiButtonGroup__button--selected euiButton--fill"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
       id="button01"
       type="button"
     >
@@ -1274,7 +1274,7 @@ exports[`EuiButtonGroup props type of multi idToSelectedMap is rendered 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
       id="button02"
       type="button"
     >
@@ -1306,7 +1306,7 @@ exports[`EuiButtonGroup props type of multi is rendered 1`] = `
   >
     <button
       aria-pressed="false"
-      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
       id="button00"
       type="button"
     >
@@ -1322,7 +1322,7 @@ exports[`EuiButtonGroup props type of multi is rendered 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
       id="button01"
       type="button"
     >
@@ -1338,7 +1338,7 @@ exports[`EuiButtonGroup props type of multi is rendered 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--no-hover"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
       id="button02"
       type="button"
     >

--- a/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -29,63 +29,54 @@ exports[`EuiButtonGroup props buttonSize compressed is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text euiButtonGroup--compressed"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -102,63 +93,54 @@ exports[`EuiButtonGroup props buttonSize m is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -175,63 +157,54 @@ exports[`EuiButtonGroup props buttonSize s is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -248,63 +221,54 @@ exports[`EuiButtonGroup props color danger is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--danger"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--danger euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--danger euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--danger euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -321,63 +285,54 @@ exports[`EuiButtonGroup props color ghost is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--ghost"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--ghost euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--ghost euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--ghost euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -394,63 +349,54 @@ exports[`EuiButtonGroup props color primary is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--primary"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--primary euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--primary euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--primary euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -467,63 +413,54 @@ exports[`EuiButtonGroup props color secondary is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--secondary"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--secondary euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--secondary euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--secondary euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -540,63 +477,54 @@ exports[`EuiButtonGroup props color text is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -613,63 +541,54 @@ exports[`EuiButtonGroup props color warning is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--warning"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--warning euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--warning euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--warning euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -686,64 +605,54 @@ exports[`EuiButtonGroup props idSelected is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--fill euiButton--small euiButtonGroup__button euiButtonGroup__button--selected"
+    <button
+      aria-pressed="true"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
+      id="button00"
+      type="button"
     >
-      <input
-        checked=""
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -760,66 +669,57 @@ exports[`EuiButtonGroup props isDisabled is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text euiButtonGroup--disabled"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--disabled euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--disabled"
+      disabled=""
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        disabled=""
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--disabled euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--disabled"
+      disabled=""
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        disabled=""
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--disabled euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButton--disabled"
+      disabled=""
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        disabled=""
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -836,63 +736,54 @@ exports[`EuiButtonGroup props isFullWidth is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text euiButtonGroup--fullWidth"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -909,63 +800,66 @@ exports[`EuiButtonGroup props isIconOnly is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
-          class="euiScreenReaderOnly"
+          class="euiButton__text"
         >
-          Option one
+          <span
+            class="euiScreenReaderOnly"
+          >
+            Option one
+          </span>
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
-          class="euiScreenReaderOnly"
+          class="euiButton__text"
         >
-          Option two
+          <span
+            class="euiScreenReaderOnly"
+          >
+            Option two
+          </span>
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButtonGroup__toggle--iconOnly euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button euiButtonGroup__button--iconOnly"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
-          class="euiScreenReaderOnly"
+          class="euiButton__text"
         >
-          Option three
+          <span
+            class="euiScreenReaderOnly"
+          >
+            Option three
+          </span>
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -982,63 +876,54 @@ exports[`EuiButtonGroup props legend is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -1055,66 +940,54 @@ exports[`EuiButtonGroup props name is rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        name="name"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        name="name"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        name="name"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -1131,63 +1004,54 @@ exports[`EuiButtonGroup props options are rendered 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button01"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button01"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button01"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option two
         </span>
-      </label>
-    </div>
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+      </span>
+    </button>
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      id="button02"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        id="button02"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button02"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option three
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;
@@ -1204,26 +1068,23 @@ exports[`EuiButtonGroup props options can pass down data-test-subj 1`] = `
   <div
     class="euiButtonGroup euiButtonGroup--text"
   >
-    <div
-      class="euiButton euiButton--no-hover euiButtonGroup__toggle euiButton--small euiButtonGroup__button"
+    <button
+      aria-pressed="false"
+      class="euiButton euiButton--text euiButton--small euiButtonGroup__button"
+      data-test-subj="test"
+      id="button00"
+      type="button"
     >
-      <input
-        class="euiButtonGroup__input"
-        data-test-subj="test"
-        id="button00"
-        type="radio"
-      />
-      <label
-        class="euiButton__content euiButtonGroup__label"
-        for="button00"
+      <span
+        class="euiButton__content"
       >
         <span
           class="euiButton__text"
         >
           Option one
         </span>
-      </label>
-    </div>
+      </span>
+    </button>
   </div>
 </fieldset>
 `;

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -43,7 +43,6 @@
   .euiButton__content {
     flex-direction: column;
     padding: 0 $euiSizeS;
-    justify-content: center;
   }
 }
 

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -9,6 +9,7 @@
 }
 
 .euiButtonGroup {
+  @include euiSlightShadow;
   max-width: 100%;
   display: flex;
   border: 1px solid $euiButtonToggleBorderColor;
@@ -52,28 +53,6 @@
   }
 }
 
-@each $name, $color in $euiButtonTypes {
-  .euiButtonGroup--#{$name} {
-    @if ($name == 'ghost') {
-      // Ghost is unique and ALWAYS sits against a dark background.
-      color: $color;
-    } @else {
-      // Other colors need to check their contrast against the page background color.
-      color: makeHighContrastColor($color, $euiPageBackgroundColor);
-    }
-
-    $shadowColor: $euiShadowColor;
-    @if ($name == 'ghost') {
-      $shadowColor: $euiColorInk;
-    } @else if (lightness($euiTextColor) < 50) {
-      // Only if this is the light theme do we use the button variant color to colorize the shadow
-      $shadowColor: desaturate($color, 60%);
-    }
-
-    @include euiSlightShadow($shadowColor);
-  }
-}
-
 .euiButtonGroup--compressed {
   border-color: $euiFormBorderColor;
   border-radius: $euiFormControlCompressedBorderRadius;
@@ -86,8 +65,8 @@
     height: $euiFormControlCompressedHeight - 2px;
     min-width: 0;
 
-    &:focus,
     &:hover,
+    &:focus,
     &--selected {
       background-color: $euiFormInputGroupLabelBackground;
     }

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,72 +1,62 @@
+
+.euiButtonGroup__fieldset {
+  display: inline-block;
+  max-width: 100%;
+
+  &--fullWidth {
+    display: block;
+  }
+}
+
 .euiButtonGroup {
   max-width: 100%;
   display: flex;
-  border-radius: $euiBorderRadius;
+  border: 1px solid $euiButtonToggleBorderColor;
+  border-radius: $euiBorderRadius; // Needed for box-shadow be rounded
+}
 
-  .euiButton {
-    border-radius: 0;
-    margin-left: -1px;
+.euiButtonGroup__button {
+  // Offset the background color from the border by 2px
+  // by clipping background to before the padding starts
+  padding: 1px;
+  background-clip: content-box;
+  // Increase border-radius because of background-clip
+  border-radius: $euiBorderRadius + 1px;
 
-    &:not(.euiButton--fill) {
-      border-color: $euiButtonToggleBorderColor;
-    }
+  // Override styling for all states and all variations
+  // sass-lint:disable-block no-important
+  border-color: transparent !important;
+  transition: none !important;
+  transform: none !important;
+  animation: none !important;
+  box-shadow: none !important;
 
-    &,
-    &:hover,
-    &:focus,
-    &:active {
-      transition: none;
-      transform: none;
-      animation: none;
-      box-shadow: none;
-    }
-
-    &.euiButton--disabled:hover {
-      text-decoration: none;
-      cursor: not-allowed;
-    }
+  &:focus {
+    outline: 2px solid $euiFocusRingColor;
   }
+}
 
-  .euiButton--fill {
-    z-index: 0;
+.euiButtonGroup__button--iconOnly {
+  min-width: 0;
+
+  .euiButton__content {
+    flex-direction: column;
+    padding: 0 $euiSizeS;
+    justify-content: center;
   }
+}
 
-  .euiButtonGroup__button--iconOnly,
-  .euiButtonGroup__toggle--iconOnly {
-    min-width: auto;
-  }
-
-  .euiButton--fill + .euiButton {
-    border-left-color: transparent;
-  }
-
-  &:not(.euiButtonGroup--compressed) {
-    .euiButton {
-      &[aria-pressed='true'] + [aria-pressed='true'] {
-        box-shadow: -1px 0 0 transparentize($euiColorEmptyShade, .9);
-      }
-
-      &:first-child {
-        border-top-left-radius: $euiBorderRadius;
-        border-bottom-left-radius: $euiBorderRadius;
-      }
-
-      &:last-child {
-        border-top-right-radius: $euiBorderRadius;
-        border-bottom-right-radius: $euiBorderRadius;
-      }
-    }
+.euiButtonGroup--fullWidth {
+  .euiButtonGroup__button {
+    flex: 1;
   }
 }
 
 @each $name, $color in $euiButtonTypes {
-  .euiButtonGroup--#{$name}:not(.euiButtonGroup--compressed) {
+  .euiButtonGroup--#{$name} {
     @if ($name == 'ghost') {
       // Ghost is unique and ALWAYS sits against a dark background.
       color: $color;
-    } @else if ($name == 'text') {
-      // The default color is lighter than the normal text color, make the it the text color
-      color: $euiTextColor;
     } @else {
       // Other colors need to check their contrast against the page background color.
       color: makeHighContrastColor($color, $euiPageBackgroundColor);
@@ -81,61 +71,43 @@
     }
 
     @include euiSlightShadow($shadowColor);
+  }
+}
 
-    .euiButtonGroup__input:focus + .euiButtonGroup__label {
-      background-color: darken($color, 5%);
-      border-color: darken($color, 5%);
-      text-decoration: underline;
+.euiButtonGroup--compressed {
+  border-color: $euiFormBorderColor;
+  border-radius: $euiFormControlCompressedBorderRadius;
+  background-color: $euiFormBackgroundColor;
+  box-shadow: none;
+
+  .euiButtonGroup__button {
+    border-radius: $euiBorderRadius;
+    font-size: $euiFontSizeS;
+    height: $euiFormControlCompressedHeight - 2px;
+    min-width: 0;
+
+    &:focus,
+    &:hover,
+    &--selected {
+      background-color: $euiFormInputGroupLabelBackground;
+    }
+
+    &--selected {
+      font-weight: $euiFontWeightSemiBold;
+    }
+  }
+
+  // Compressed button groups are for use with forms,
+  // so when using the `text` color variant, change the colors
+  // to match that of forms
+  &.euiButtonGroup--text .euiButtonGroup__button {
+    &:not(.euiButtonGroup__button--selected):not(.euiButton--disabled) {
+      color: $euiColorDarkShade;
     }
   }
 }
 
-.euiButtonGroup__button {
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-.euiButtonGroup__fieldset {
-  display: inline-block;
-  max-width: 100%;
-
-  &--fullWidth {
-    display: block;
-  }
-}
-
-.euiButtonGroup__input {
-  @include euiScreenReaderOnly;
-}
-
-.euiButtonGroup--fullWidth {
-  .euiButtonGroup__toggle {
-    flex: 1;
-  }
-}
-
-.euiButtonGroup__label {
-  white-space: nowrap;
-  cursor: inherit;
-
-  .euiButton--disabled & {
-    pointer-events: none;
-  }
-}
-
-.euiButtonGroup__button--iconOnly {
-  .euiButton__content {
-    flex-direction: column;
-    padding: 0 $euiSizeS;
-    justify-content: center;
-  }
-
-  .euiIcon {
-    color: inherit;
-    margin: 0;
-  }
-}
-
+// Force `fullWidth` style on small screens
 @include euiBreakpoint('xs', 's') {
   .euiButtonGroup__fieldset {
     display: block;
@@ -147,46 +119,3 @@
   }
 }
 
-.euiButtonGroup--compressed {
-  border: 1px solid $euiFormBorderColor;
-  border-radius: $euiFormControlCompressedBorderRadius;
-  background-color: $euiFormBackgroundColor;
-
-  .euiButtonGroup__button:focus,
-  .euiButtonGroup__input:focus + .euiButtonGroup__label {
-    outline: 2px solid $euiFocusRingColor;
-  }
-
-  .euiButtonGroup__button {
-    border: none;
-    background: none;
-    border-radius: $euiBorderRadius;
-    font-size: $euiFontSizeS;
-    height: $euiFormControlCompressedHeight - 2px;
-    box-shadow: none;
-    min-width: 0;
-    // Offset the background color from the border by 2px
-    // by clipping background to before the padding starts
-    padding: 2px;
-    background-clip: content-box;
-
-    &:not(.euiButtonGroup__button--selected):not(.euiButton--disabled) {
-      color: $euiColorDarkShade;
-    }
-
-    &:hover,
-    &:focus {
-      box-shadow: none;
-    }
-  }
-
-  .euiButtonGroup__button--selected {
-    font-weight: $euiFontWeightSemiBold;
-    background-color: $euiFormInputGroupLabelBackground;
-  }
-
-  .euiButton__content {
-    padding-left: $euiSizeS;
-    padding-right: $euiSizeS;
-  }
-}

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -169,7 +169,7 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
             className
           );
 
-          if (type === 'multi') {
+          if (type) {
             return (
               <EuiButton
                 className={buttonClasses}
@@ -179,7 +179,7 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
                 isDisabled={optionDisabled || isDisabled}
                 aria-pressed={isSelectedState}
                 size={buttonSize === 'compressed' ? 's' : buttonSize}
-                onClick={() => onChange(id)}
+                onClick={() => onChange(id, value)}
                 key={index}
                 iconSide={iconSide}
                 iconType={iconType}

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -3,12 +3,11 @@ import React, { FunctionComponent, HTMLAttributes, ReactNode } from 'react';
 import { EuiScreenReaderOnly } from '../../accessibility';
 import { CommonProps } from '../../common';
 import { IconType } from '../../icon';
-import { ToggleType } from '../../toggle';
 import {
   ButtonColor,
   ButtonIconSide,
   EuiButton,
-  colorToClassNameMap,
+  // colorToClassNameMap,
 } from '../button';
 import { EuiIcon } from '../../icon/icon';
 
@@ -18,32 +17,81 @@ export interface EuiButtonGroupIdToSelectedMap {
 
 export type GroupButtonSize = 's' | 'm' | 'compressed';
 
-export interface EuiButtonGroupOption extends CommonProps {
+export interface EuiButtonGroupOptionProps extends CommonProps {
+  /**
+   * Each option must have a unique `id` for maintaining selection
+   */
   id: string;
+  /**
+   * Each option must have a `label` even for icons which will be applied as the `aria-label`
+   */
   label: ReactNode;
+  /**
+   * *DEPRECATED:* Was necessary when toggles were inputs, but now they're buttons.
+   * Use `label` instead
+   */
   name?: string;
   isDisabled?: boolean;
-  value?: any;
+  /**
+   * The value of the radio input.
+   * Only necessary/used when `type="single"`
+   */
+  value?: string;
   iconSide?: ButtonIconSide;
+  /**
+   * Any `type` accepted by EuiIcon
+   */
   iconType?: IconType;
 }
 
 export interface EuiButtonGroupProps extends CommonProps {
-  options?: EuiButtonGroupOption[];
-  onChange: (id: string, value?: any) => void;
+  /**
+   * An array of #EuiButtonGroupOption
+   */
+  options?: EuiButtonGroupOptionProps[];
+  /**
+   * Returns the `id` of the clicked option and the `value`
+   * if it is of `type="single"`
+   */
+  onChange: (id: string, value?: string) => void;
   /**
    * Typical sizing is `s`. Medium `m` size should be reserved for major features.
    * `compressed` is meant to be used alongside and within compressed forms.
    */
   buttonSize?: GroupButtonSize;
   isDisabled?: boolean;
+  /**
+   * Expands the whole group to the full width of the container.
+   * Each button gets equal widths no matter the content
+   */
   isFullWidth?: boolean;
+  /**
+   * Hides the label to only show the `iconType` provided by the `option`
+   */
   isIconOnly?: boolean;
+  /**
+   * Styles the selected option to look selected (usually with `fill`)
+   */
   idSelected?: string;
+  /**
+   * A hidden group title. Required for accessibility
+   */
   legend: string;
   color?: ButtonColor;
+  /**
+   * The `name` attribute for radio inputs. Only necessary/used when `type="single"`
+   */
   name?: string;
-  type?: ToggleType;
+  /**
+   * Determines how the selection of the group should be handled.
+   * With `'single'` only one option can be selected at a time (similar to radio group).
+   * With `'multi'` multiple options selected (similar to checkbox group).
+   */
+  type?: 'single' | 'multi';
+  /**
+   * A map of `id`s as keys with the selected boolean values.
+   * Only necessary/used when `type="single"`
+   */
   idToSelectedMap?: EuiButtonGroupIdToSelectedMap;
 }
 
@@ -64,7 +112,6 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
   onChange,
   options = [],
   type = 'single',
-  'data-test-subj': dataTestSubj,
   ...rest
 }) => {
   const classes = classNames(
@@ -99,7 +146,7 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
             className,
             iconType,
             iconSide,
-            ...rest
+            ...optionRest
           } = option;
 
           let isSelectedState;
@@ -115,7 +162,6 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
           }
           const buttonClasses = classNames(
             'euiButtonGroup__button',
-            'euiButton--no-hover',
             {
               'euiButtonGroup__button--selected': isSelectedState,
               'euiButtonGroup__button--iconOnly': isIconOnly,
@@ -133,12 +179,11 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
                 isDisabled={optionDisabled || isDisabled}
                 aria-pressed={isSelectedState}
                 size={buttonSize === 'compressed' ? 's' : buttonSize}
-                onClick={() => onChange(id, value)}
-                data-test-subj={dataTestSubj}
+                onClick={() => onChange(id)}
                 key={index}
                 iconSide={iconSide}
                 iconType={iconType}
-                {...rest}>
+                {...optionRest}>
                 {isIconOnly ? (
                   <EuiScreenReaderOnly>
                     <span>{label}</span>
@@ -154,7 +199,7 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
             'euiButton',
             'euiButton--no-hover',
             'euiButtonGroup__toggle',
-            color ? colorToClassNameMap[color] : null,
+            // color ? colorToClassNameMap[color] : null,
             {
               'euiButton--disabled': isDisabled,
               'euiButtonGroup__toggle--iconOnly': isIconOnly,
@@ -171,18 +216,17 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
 
           const isActuallyDisabled = optionDisabled || isDisabled;
           return (
-            <div className={wrapperClasses} key={index} {...rest}>
+            <div className={wrapperClasses} key={index}>
               <input
                 id={id}
                 className="euiButtonGroup__input"
-                name={optionName || name}
+                name={name}
                 onChange={() => onChange(id, value)}
                 checked={isSelectedState}
-                data-test-subj={dataTestSubj}
                 disabled={isActuallyDisabled}
                 value={value}
                 type="radio"
-                {...rest}
+                {...optionRest}
               />
               <label
                 htmlFor={id}

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -125,6 +125,14 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
     className
   );
 
+  // Compressed style can't support `ghost` color because it's more like a form field than a button
+  const badColorCombo = buttonSize === 'compressed' && color === 'ghost';
+  if (badColorCombo) {
+    console.warn(
+      'EuiButtonGroup of compressed size does not support the ghost color. It will render as text instead.'
+    );
+  }
+
   const fieldsetClasses = classNames('euiButtonGroup__fieldset', {
     'euiButtonGroup__fieldset--fullWidth': isFullWidth,
   });
@@ -174,7 +182,7 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
               <EuiButton
                 className={buttonClasses}
                 id={id}
-                color={color}
+                color={badColorCombo ? 'text' : color}
                 fill={fill}
                 isDisabled={optionDisabled || isDisabled}
                 aria-pressed={isSelectedState}

--- a/src/components/button/button_group/index.ts
+++ b/src/components/button/button_group/index.ts
@@ -1,5 +1,5 @@
 export {
   EuiButtonGroup,
-  EuiButtonGroupOption,
+  EuiButtonGroupOptionProps,
   EuiButtonGroupProps,
 } from './button_group';

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -29,7 +29,7 @@ export type EuiButtonIconColor =
   | 'text'
   | 'warning';
 
-export type HideOrLabel = ExclusiveUnion<
+type HideOrLabel = ExclusiveUnion<
   { 'aria-hidden': true },
   ExclusiveUnion<{ 'aria-label': string }, { 'aria-labelledby': string }>
 >;

--- a/src/components/button/button_icon/index.ts
+++ b/src/components/button/button_icon/index.ts
@@ -3,5 +3,4 @@ export {
   EuiButtonIconColor,
   EuiButtonIconProps,
   EuiButtonIconPropsForButton,
-  HideOrLabel,
 } from './button_icon';

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -25,6 +25,6 @@ export { EuiButtonToggle, EuiButtonToggleProps } from './button_toggle';
 
 export {
   EuiButtonGroup,
-  EuiButtonGroupOption,
+  EuiButtonGroupOptionProps,
   EuiButtonGroupProps,
 } from './button_group';

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -5,7 +5,6 @@ export {
   ButtonIconSide,
   EuiButton,
   EuiButtonProps,
-  colorToClassNameMap,
 } from './button';
 
 export {
@@ -20,7 +19,6 @@ export {
   EuiButtonIconColor,
   EuiButtonIconProps,
   EuiButtonIconPropsForButton,
-  HideOrLabel,
 } from './button_icon';
 
 export { EuiButtonToggle, EuiButtonToggleProps } from './button_toggle';

--- a/src/themes/eui-amsterdam/overrides/_button.scss
+++ b/src/themes/eui-amsterdam/overrides/_button.scss
@@ -9,7 +9,7 @@
   // Added exclusion of the `ghost` type of button
   // so as not to override those specific styles from default theme
   // And the only style that needs to change is the non-filled version
-  &:disabled:not(.euiButton--ghost):not(.euiButton--fill) {
+  &.euiButton--disabled:not(.euiButton--ghost):not(.euiButton--fill) {
     $backgroundColorSimulated: mix($euiPageBackgroundColor, $euiButtonColorDisabled, 70%);
     background-color: transparentize($euiButtonColorDisabled, .7);
     color: makeHighContrastColor($euiButtonColorDisabled, $backgroundColorSimulated, 2);
@@ -42,7 +42,7 @@
     // But still use transparency
     background-color: transparentize($color, .8);
 
-    &:enabled {
+    &:not(.euiButton--disabled) {
       &:hover,
       &:focus {
         background-color: transparentize($color, lightOrDarkTheme(.9, .65));
@@ -59,7 +59,7 @@
 }
 
 // Fix ghost/disabled look specifically
-.euiButton:disabled.euiButton--ghost:not(.euiButton--fill) {
+.euiButton.euiButton--disabled.euiButton--ghost:not(.euiButton--fill) {
   &,
   &:hover,
   &:focus {


### PR DESCRIPTION
This fixes up the Docs, adds props comments, cleans up the SASS, and fixes some exports

I also styled the buttons more like the compressed version so they'll be visually different (I'll get ok's from the other designers later).

<img width="970" alt="Screen Shot 2020-04-09 at 19 21 10 PM" src="https://user-images.githubusercontent.com/549577/78948841-b09dbf80-7a97-11ea-989e-f646b13c2f14.png">

Right now I"m only rendering the `<EuiButton>` versions for both types but I left the code in for the other type for now.

I brute force pushed these commits because there were downstream breaks test breaks but I don't want to fix those til we have a final solution for what the DOM renders.