### PR TITLE
A few edits

### DIFF
--- a/src-docs/src/views/form_layouts/accessible_labels.js
+++ b/src-docs/src/views/form_layouts/accessible_labels.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   EuiButton,
   EuiCode,
-  EuiDescribedFormGroup,
   EuiForm,
   EuiFormRow,
   EuiSwitch,
@@ -13,51 +12,39 @@ export default () => {
 
   return (
     <EuiForm component="form">
-      <EuiDescribedFormGroup
-        title={<h3>Not as simple as they look</h3>}
-        description={
+      <EuiFormRow
+        label="Settings"
+        helpText={
           <>
-            Some form controls come with their own label and don&lsquo;t need
-            the one provided by <strong>EuiFormRow</strong>. Include{' '}
-            <EuiCode>hasChildLabel:false</EuiCode> on form rows that wrap:{' '}
-            <EuiCode>EuiSwitch</EuiCode>, <EuiCode>EuiButton</EuiCode>, or{' '}
-            <EuiCode>EuiLink</EuiCode>.
+            Navigate to this Switch with a screen reader. With{' '}
+            <EuiCode>hasChildLabel = false</EuiCode> the name of this is
+            &ldquo;Dark mode?&rdquo; instead of &ldquo;Settings&rdquo;.
+          </>
+        }
+        hasChildLabel={false}>
+        <EuiSwitch
+          name="switch"
+          label="Dark mode?"
+          onChange={() => {
+            setCheckedState(false);
+            setTimeout(() => {
+              setCheckedState(true);
+            }, 500);
+          }}
+          checked={checkedState}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label="Your cluster data"
+        helpText={
+          <>
+            Navigate to this Switch with a screen reader. With{' '}
+            <EuiCode>hasChildLabel = true</EuiCode> the name of this switch is
+            &ldquo;Your cluster data&rdquo; instead of &ldquo;Download&rdquo;.
           </>
         }>
-        <EuiFormRow
-          label="Settings"
-          helpText={
-            <>
-              Navigate to this Switch with a screen reader - with{' '}
-              <EuiCode>hasChildLabel:false</EuiCode> the name of this is
-              &rdquo;Dark mode?&ldquo; instead of &rdquo;Settings&ldquo;.
-            </>
-          }
-          hasChildLabel={false}>
-          <EuiSwitch
-            name="switch"
-            label="Dark mode?"
-            onChange={() => {
-              setCheckedState(false);
-              setTimeout(() => {
-                setCheckedState(true);
-              }, 500);
-            }}
-            checked={checkedState}
-          />
-        </EuiFormRow>
-        <EuiFormRow
-          label="Your cluster data"
-          helpText={
-            <>
-              Navigate to this Switch with a screen reader - without{' '}
-              <EuiCode>hasChildLabel:false</EuiCode> the name of this switch is
-              &rdquo;Your cluster data&ldquo; instead of &rdquo;Download&ldquo;.
-            </>
-          }>
-          <EuiButton>Download</EuiButton>
-        </EuiFormRow>
-      </EuiDescribedFormGroup>
+        <EuiButton>Download</EuiButton>
+      </EuiFormRow>
     </EuiForm>
   );
 };

--- a/src-docs/src/views/form_layouts/difficult_accessibility_labels.js
+++ b/src-docs/src/views/form_layouts/difficult_accessibility_labels.js
@@ -1,55 +1,47 @@
 import React from 'react';
 import {
   EuiCode,
-  EuiDescribedFormGroup,
   EuiForm,
   EuiFormRow,
   EuiSelectable,
 } from '../../../../src/components';
 
 export default () => {
+  const labelText = 'Tea categories';
+
   return (
     <EuiForm component="form">
-      <EuiDescribedFormGroup
-        title={<h3>Some controls are just hard though</h3>}
-        description={
+      <EuiFormRow
+        label={labelText}
+        fullWidth
+        helpText={
           <>
-            More complicated form controls will often require some custom work.
-            Refer to an individual component&lsquo;s documentation and remember
-            to test!
+            The <strong>EuiFormRow</strong> label can&lsquo;t reach{' '}
+            <strong>EuiSelectable</strong> without some help. Use{' '}
+            <EuiCode>aria-label</EuiCode> or <EuiCode>aria-labelledby</EuiCode>{' '}
+            to give a name to <strong>EuiSelectable</strong> that screen readers
+            can use too.
           </>
         }>
-        <EuiFormRow
-          label="Tea categories"
-          helpText={
+        <EuiSelectable
+          searchable
+          aria-label={labelText}
+          options={[
+            { label: 'Black' },
+            { label: 'Oolong' },
+            { label: 'Green' },
+            { label: 'White' },
+            { label: 'Herbal' },
+          ]}
+          onChange={() => {}}>
+          {(list, search) => (
             <>
-              The <strong>EuiFormRow</strong> label can&lsquo;t reach{' '}
-              <strong>EuiSelectable</strong> without some help. Use{' '}
-              <EuiCode>aria-label</EuiCode> or{' '}
-              <EuiCode>aria-labelledby</EuiCode> to give a name to{' '}
-              <strong>EuiSelectable</strong> that screen readers can use too.
+              {search}
+              {list}
             </>
-          }>
-          <EuiSelectable
-            searchable
-            aria-label="Tea categories"
-            options={[
-              { label: 'Black' },
-              { label: 'Oolong' },
-              { label: 'Green' },
-              { label: 'White' },
-              { label: 'Herbal' },
-            ]}
-            onChange={() => {}}>
-            {(list, search) => (
-              <>
-                {search}
-                {list}
-              </>
-            )}
-          </EuiSelectable>
-        </EuiFormRow>
-      </EuiDescribedFormGroup>
+          )}
+        </EuiSelectable>
+      </EuiFormRow>
     </EuiForm>
   );
 };

--- a/src-docs/src/views/form_layouts/form_layouts_example.js
+++ b/src-docs/src/views/form_layouts/form_layouts_example.js
@@ -150,20 +150,30 @@ export const FormLayoutsExample = {
 </EuiDescribedFormGroup>`,
     },
     {
-      title: 'Accessible labels',
+      title: 'Form labels',
       text: (
-        <p>
-          Because of the many form elements and the flexibility offered by EUI,
-          sometimes extra care has to be taken to ensure an accessible
-          experience. There are a lot of ways to achieve this and only some will
-          be covered but the import end result is that every form control has an{' '}
-          <EuiLink
-            href="https://www.tpgi.com/what-is-an-accessible-name/"
-            external>
-            accessible name
-          </EuiLink>
-          .
-        </p>
+        <>
+          <p>
+            The best way to provide an{' '}
+            <EuiLink
+              href="https://www.tpgi.com/what-is-an-accessible-name/"
+              external>
+              accessible name
+            </EuiLink>{' '}
+            to form elements is to use the <EuiCode>label</EuiCode> prop
+            provided by <strong>EuiFormRow</strong>. However, certain types of
+            form controls require extra care to ensure an accessible experience.
+            Below are just a few examples.
+          </p>
+          <p>
+            Form controls that come with their own label don&lsquo;t need the
+            one provided by <strong>EuiFormRow</strong>. For controls like{' '}
+            <EuiCode>EuiSwitch</EuiCode>, <EuiCode>EuiButton</EuiCode>, and{' '}
+            <EuiCode>EuiLink</EuiCode> be sure to pass{' '}
+            <EuiCode>{'hasChildLabel={false}'}</EuiCode> to the wrapping{' '}
+            <strong>EuiFormRow</strong>.
+          </p>
+        </>
       ),
       demo: <AccessibleLabels />,
       source: [
@@ -175,6 +185,26 @@ export const FormLayoutsExample = {
       snippet: accessibleLabelsSnippet,
     },
     {
+      text: (
+        <>
+          <h3>Implicit titles for the first form control</h3>
+          <p>
+            When displaying the form control&apos;s name in some other way than
+            through the visual <EuiCode>label</EuiCode> prop, the form control
+            still needs to be associated with that element. To do this, either:
+          </p>
+          <ul>
+            <li>
+              duplicate the text and pass it as the{' '}
+              <EuiCode>aria-label</EuiCode> of the form control, or
+            </li>
+            <li>
+              pass the <EuiCode>id</EuiCode> of the text to the form
+              control&apos;s <EuiCode>aria-labelledby</EuiCode>.
+            </li>
+          </ul>
+        </>
+      ),
       demo: <ImplicitTitles />,
       source: [
         {
@@ -185,6 +215,16 @@ export const FormLayoutsExample = {
       snippet: implicitTitleSnippet,
     },
     {
+      text: (
+        <>
+          <h3>More complicated form labels</h3>
+          <p>
+            Some controls are just hard though and will often require some
+            custom work. Refer to an individual component&lsquo;s documentation
+            and remember to test with a screen reader!
+          </p>
+        </>
+      ),
       demo: <DifficultAccessibleLabels />,
       source: [
         {

--- a/src-docs/src/views/form_layouts/implicit_titles.js
+++ b/src-docs/src/views/form_layouts/implicit_titles.js
@@ -13,7 +13,7 @@ import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
   const randomId = htmlIdGenerator()();
-  const titleText = 'Implicit titles for the first form control';
+  const titleText = 'Implicit titles';
 
   return (
     <EuiForm component="form">
@@ -21,11 +21,8 @@ export default () => {
         title={<h3 id={randomId}>{titleText}</h3>}
         description={
           <>
-            Often, we won&lsquo;t put a visual label on the first form field.
-            But the form field still needs to be associated with the title
-            somehow: use <EuiCode>aria-label</EuiCode> to pass in the form title
-            text again or <EuiCode>aria-labelledby</EuiCode> to pass in the{' '}
-            <EuiCode>id</EuiCode> of the title.
+            <strong>EuiDescribedFormGroup</strong> components tend to use this
+            pattern as the title and label are usually the same.
           </>
         }>
         <EuiFormRow

--- a/src-docs/src/views/guidelines/accessibility.js
+++ b/src-docs/src/views/guidelines/accessibility.js
@@ -28,49 +28,63 @@ export default {
   title: 'Accessibility guidelines',
   intro: (
     <>
-      <EuiText grow={false}>
+      <EuiText color="subdued" size="s" grow={false}>
         <p>
-          EUI provides a strong start to building accessibility into your apps.
-          The components provided strive to meet{' '}
-          <EuiLink href="https://www.w3.org/TR/WCAG21/">WCAG 2.1</EuiLink>{' '}
-          guidelines on semantics, keyboard functionality, color contrast, and
-          so on. How you stitch together these components in the overall page
-          structure also plays a large role in meeting accessibility goals.
-          Headings, landmarks, page titles, focus management, and accessible
-          names all work together to create accessible apps.
-        </p>
-        <p>
-          Building accessibility into your app is as important as code quality,
-          visual design, and performance, and it’s also important that you test
-          as you go. You can approach accessibility testing from three
-          dimensions: automated, manual, and empathetic thinking. Use automated
-          tests to quickly cover as much ground as possible, manual tests to
-          address more complicated scenarios, and empathy to fill in the gaps.
+          This page provides some general accessibility guidelines. For
+          component specific recommendations, be sure to check out their
+          individual documentation pages.
         </p>
       </EuiText>
-
-      <EuiSpacer size="xl" />
-      <EuiTitle size="xs">
-        <p>For a technical intro to accessibility and how EUI tackles it</p>
-      </EuiTitle>
-
-      <EuiSpacer size="l" />
-
-      <EuiAspectRatio width={16} height={9} maxWidth={700}>
-        <iframe
-          title="Building and Testing for Accessibility with EUI"
-          width="560"
-          height="315"
-          src="https://www.youtube-nocookie.com/embed/iDXoEe8NkrE"
-          frameBorder="0"
-          allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-        />
-      </EuiAspectRatio>
-      <EuiSpacer size="xl" />
     </>
   ),
   sections: [
+    {
+      wrapText: false,
+      text: (
+        <>
+          <EuiText grow={false}>
+            <p>
+              EUI provides a strong start to building accessibility into your
+              apps. The components provided strive to meet{' '}
+              <EuiLink href="https://www.w3.org/TR/WCAG21/">WCAG 2.1</EuiLink>{' '}
+              guidelines on semantics, keyboard functionality, color contrast,
+              and so on. How you stitch together these components in the overall
+              page structure also plays a large role in meeting accessibility
+              goals. Headings, landmarks, page titles, focus management, and
+              accessible names all work together to create accessible apps.
+            </p>
+            <p>
+              Building accessibility into your app is as important as code
+              quality, visual design, and performance, and it’s also important
+              that you test as you go. You can approach accessibility testing
+              from three dimensions: automated, manual, and empathetic thinking.
+              Use automated tests to quickly cover as much ground as possible,
+              manual tests to address more complicated scenarios, and empathy to
+              fill in the gaps.
+            </p>
+          </EuiText>
+
+          <EuiSpacer size="xl" />
+          <EuiTitle size="xs">
+            <p>For a technical intro to accessibility and how EUI tackles it</p>
+          </EuiTitle>
+
+          <EuiSpacer size="l" />
+
+          <EuiAspectRatio width={16} height={9}>
+            <iframe
+              title="Building and Testing for Accessibility with EUI"
+              width="560"
+              height="315"
+              src="https://www.youtube-nocookie.com/embed/iDXoEe8NkrE"
+              frameBorder="0"
+              allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </EuiAspectRatio>
+        </>
+      ),
+    },
     {
       title: 'Headings and landmarks',
       wrapText: false,


### PR DESCRIPTION
The main goal here was to pull out the "documentation", meaning the real text people need to read out of the examples themselves and rewording a little bit to be either more succinct, or EUI specific (calling out more component names/props).